### PR TITLE
Prepare release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.2.1 - 2025-08-29]
+
+### Changed
+- npm packages updated 
+- max NC version bumped to 32
+- CSP Nonce updated
+- change icons to outlined versions
+
 ## [1.2.0 - 2025-01-21]
 
 Maintenance update. NC31 support.

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -4,7 +4,7 @@
 	<name>Profile picker</name>
 	<summary>Profile smart picker and link preview</summary>
 	<description><![CDATA[This app adds ability to search for user profiles via smart picker and link previews for them.]]></description>
-	<version>1.2.0</version>
+	<version>1.2.1</version>
 	<licence>agpl</licence>
 	<author mail="andrey18106x@gmail.com" homepage="https://github.com/andrey18106">Andrey Borysenko</author>
 	<namespace>UsersPicker</namespace>


### PR DESCRIPTION
### Changed
- npm packages updated 
- max NC version bumped to 32
- CSP Nonce updated
- change icons to outlined versions